### PR TITLE
pods per node

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Monitors:
   * [Node Memorypressure](#node-memorypressure)
   * [Network Unavailable](#network-unavailable)
   * [Deploy Desired Vs Status](#deploy-desired-vs-status)
+  * [Pod Count Per Node High](#pod-count-per-node-high)
   * [Node Memory Used Percent](#node-memory-used-percent)
   * [Datadog Agent](#datadog-agent)
   * [Hpa Status](#hpa-status)
@@ -258,6 +259,31 @@ avg(${var.deploy_desired_vs_status_evaluation_period}):max:kubernetes_state.depl
 | deploy_desired_vs_status_notify_no_data    | False                                    | No       |                                  |
 | deploy_desired_vs_status_ok_threshold      | null                                     | No       |                                  |
 | deploy_desired_vs_status_priority          | 3                                        | No       | Number from 1 (high) to 5 (low). |
+
+
+## Pod Count Per Node High
+
+Query:
+```terraform
+avg(${var.pod_count_per_node_high_evaluation_period}):sum:kubernetes.pods.running{${local.pod_count_per_node_high_filter}} by {host} > ${var.pod_count_per_node_high_critical}
+```
+
+| variable                                  | default  | required | description                      |
+|-------------------------------------------|----------|----------|----------------------------------|
+| pod_count_per_node_high_enabled           | True     | No       |                                  |
+| pod_count_per_node_high_warning           | 90.0     | No       |                                  |
+| pod_count_per_node_high_critical          | 100.0    | No       |                                  |
+| pod_count_per_node_high_evaluation_period | last_10m | No       |                                  |
+| pod_count_per_node_high_note              | ""       | No       |                                  |
+| pod_count_per_node_high_docs              | ""       | No       |                                  |
+| pod_count_per_node_high_filter_override   | ""       | No       |                                  |
+| pod_count_per_node_high_alerting_enabled  | True     | No       |                                  |
+| pod_count_per_node_high_no_data_timeframe | null     | No       |                                  |
+| pod_count_per_node_high_notify_no_data    | False    | No       |                                  |
+| pod_count_per_node_high_ok_threshold      | null     | No       |                                  |
+| pod_count_per_node_high_name_prefix       | ""       | No       |                                  |
+| pod_count_per_node_high_name_suffix       | ""       | No       |                                  |
+| pod_count_per_node_high_priority          | 2        | No       | Number from 1 (high) to 5 (low). |
 
 
 ## Node Memory Used Percent

--- a/pod-count-per-node-high-variables.tf
+++ b/pod-count-per-node-high-variables.tf
@@ -1,0 +1,71 @@
+variable "pod_count_per_node_high_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "pod_count_per_node_high_warning" {
+  type    = number
+  default = 90.0
+}
+
+variable "pod_count_per_node_high_critical" {
+  type    = number
+  default = 100.0
+}
+
+variable "pod_count_per_node_high_evaluation_period" {
+  type    = string
+  default = "last_10m"
+}
+
+variable "pod_count_per_node_high_note" {
+  type    = string
+  default = ""
+}
+
+variable "pod_count_per_node_high_docs" {
+  type    = string
+  default = ""
+}
+
+variable "pod_count_per_node_high_filter_override" {
+  type    = string
+  default = ""
+}
+
+variable "pod_count_per_node_high_alerting_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "pod_count_per_node_high_no_data_timeframe" {
+  type    = number
+  default = null
+}
+
+variable "pod_count_per_node_high_notify_no_data" {
+  type    = bool
+  default = false
+}
+
+variable "pod_count_per_node_high_ok_threshold" {
+  type    = number
+  default = null
+}
+
+variable "pod_count_per_node_high_name_prefix" {
+  type    = string
+  default = ""
+}
+
+variable "pod_count_per_node_high_name_suffix" {
+  type    = string
+  default = ""
+}
+
+variable "pod_count_per_node_high_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = 2
+}

--- a/pod-count-per-node-high.tf
+++ b/pod-count-per-node-high.tf
@@ -1,0 +1,37 @@
+locals {
+  pod_count_per_node_high_filter = coalesce(
+    var.pod_count_per_node_high_filter_override,
+    var.filter_str
+  )
+}
+
+module "pod_count_per_node_high" {
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+
+  name  = "Pod count per node high"
+  query = "avg(${var.pod_count_per_node_high_evaluation_period}):sum:kubernetes.pods.running{${local.pod_count_per_node_high_filter}} by {host} > ${var.pod_count_per_node_high_critical}"
+
+  # alert specific configuration
+  require_full_window = false
+  alert_message       = "Pod count per node high ({{ value }}) in {{ service }} exceeds {{ threshold }}"
+  recovery_message    = "Pod count per node high ({{ value }}) in {{ service }} has recovered"
+
+  # monitor level vars
+  enabled            = var.pod_count_per_node_high_enabled
+  alerting_enabled   = var.pod_count_per_node_high_alerting_enabled
+  warning_threshold  = var.pod_count_per_node_high_warning
+  critical_threshold = var.pod_count_per_node_high_critical
+  priority           = var.pod_count_per_node_high_priority
+  docs               = var.pod_count_per_node_high_docs
+  note               = var.pod_count_per_node_high_note
+
+  # module level vars
+  env                  = var.env
+  service              = var.service
+  service_display_name = var.service_display_name
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
+  name_prefix          = var.name_prefix
+  name_suffix          = var.name_suffix
+}


### PR DESCRIPTION
This monitor informs you if you're reaching the maximum number of pods on the node. The alert is set conservatively