### PR TITLE
Capacity metrics fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,7 +811,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 Query:
 ```terraform
-max(last_5m):(sum:kubernetes.cpu.requests{tag:xxx} by {host,cluster_name} / max:system.cpu.num_cores{tag:xxx} by {host,cluster_name}) * 100 > 100
+max(last_5m):(sum:kubernetes.cpu.limits{tag:xxx} by {host,cluster_name} / max:system.cpu.num_cores{tag:xxx} by {host,cluster_name}) * 100 > 100
 ```
 
 | variable                              | default                                  | required | description                      |

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ min(last_10m):sum:kubernetes.pods.running{tag:xxx} by {host} > 100.0
 
 Query:
 ```terraform
-avg(last_5m):( 100 * max:kubernetes.memory.usage{tag:xxx} by {host,cluster_name} ) / max:kubernetes.memory.capacity{tag:xxx} by {host,cluster_name} > 90
+avg(last_5m):( 100 * max:kubernetes.memory.usage{tag:xxx} by {host,cluster_name} ) / max:system.mem.total{tag:xxx} by {host,cluster_name} > 90
 ```
 
 | variable                                   | default  | required | description                      |
@@ -388,7 +388,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 Query:
 ```terraform
-max(last_5m):sum:kubernetes.cpu.capacity{tag:xxx} by {host,cluster_name} - sum:kubernetes.cpu.requests{tag:xxx} by {host,cluster_name} < 0.5
+max(last_5m):max:system.cpu.num_cores{tag:xxx} by {cluster_name,host} - sum:kubernetes.cpu.requests{tag:xxx} by {cluster_name,host} < 0.5
 ```
 
 | variable                           | default                                  | required | description                                                                                          |
@@ -437,7 +437,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 Query:
 ```terraform
-avg(last_5m):max:kubernetes.memory.capacity{tag:xxx} by {host,cluster_name} - max:kubernetes.memory.limits{tag:xxx} by {host,cluster_name} < 3000000000
+avg(last_5m):max:system.mem.total{tag:xxx} by {host,cluster_name} - max:kubernetes.memory.limits{tag:xxx} by {host,cluster_name} < 3000000000
 ```
 
 | variable                            | default                                  | required | description                                                                                          |
@@ -509,7 +509,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 Query:
 ```terraform
-max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.memory.requests{${local.cpu_requests_low_perc_filter}} / max:kubernetes.memory.capacity{${local.cpu_requests_low_perc_filter}} ) * 100 > ${var.cpu_requests_low_perc_critical}
+max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.memory.requests{${local.cpu_requests_low_perc_filter}} / max:system.mem.total{${local.cpu_requests_low_perc_filter}} ) * 100 > ${var.cpu_requests_low_perc_critical}
 ```
 
 | variable                                   | default                                  | required | description                      |
@@ -534,7 +534,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 Query:
 ```terraform
-max(last_5m):sum:kubernetes.cpu.capacity{tag:xxx} by {host,cluster_name} - sum:kubernetes.cpu.limits{tag:xxx} by {host,cluster_name} < ${-30}
+min(last_5m):max:system.cpu.num_cores{tag:xxx} by {cluster_name,host} - sum:kubernetes.cpu.limits{tag:xxx} by {cluster_name,host} < ${-30}
 ```
 
 | variable                         | default                                  | required | description                                                                                          |
@@ -661,7 +661,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 Query:
 ```terraform
-max(last_5m):( max:kubernetes.cpu.requests{tag:xxx} by {host,cluster_name} / max:kubernetes.cpu.capacity{tag:xxx} by {host,cluster_name} ) * 100 > 95
+max(last_5m):100 * sum:kubernetes.cpu.requests{tag:xxx} by {cluster_name,host} / max:system.cpu.num_cores{tag:xxx} by {cluster_name,host} > 95
 ```
 
 | variable                                | default                                  | required | description                      |
@@ -786,7 +786,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 Query:
 ```terraform
-max(last_5m):( max:kubernetes.memory.limits{tag:xxx}  by {host,cluster_name}/ max:kubernetes.memory.capacity{tag:xxx} by {host,cluster_name}) * 100 > 100
+max(last_5m):( max:kubernetes.memory.limits{tag:xxx}  by {host,cluster_name}/ max:system.mem.total{tag:xxx} by {host,cluster_name}) * 100 > 100
 ```
 
 | variable                                 | default                                  | required | description                      |
@@ -811,7 +811,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 Query:
 ```terraform
-max(last_5m):( max:kubernetes.cpu.limits{tag:xxx} by {host,cluster_name} / max:kubernetes.cpu.capacity{tag:xxx} by {host,cluster_name}) * 100 > 100
+max(last_5m):(sum:kubernetes.cpu.requests{tag:xxx} by {host,cluster_name} / max:system.cpu.num_cores{tag:xxx} by {host,cluster_name}) * 100 > 100
 ```
 
 | variable                              | default                                  | required | description                      |
@@ -836,7 +836,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 Query:
 ```terraform
-avg(last_5m):max:kubernetes.memory.capacity{tag:xxx} by {host,cluster_name} - max:kubernetes.memory.requests{tag:xxx} by {host,cluster_name} < 3000000000
+avg(last_5m):max:system.mem.total{tag:xxx} by {host,cluster_name} - max:kubernetes.memory.requests{tag:xxx} by {host,cluster_name} < 3000000000
 ```
 
 | variable                              | default                                  | required | description                                                                                          |
@@ -871,5 +871,6 @@ avg(last_5m):max:kubernetes.memory.capacity{tag:xxx} by {host,cluster_name} - ma
 | name_prefix              | ""         | No       |                                                                                      |
 | name_suffix              | ""         | No       |                                                                                      |
 | filter_str_concatenation | ,          | No       | If you use an IN expression you need to switch from , to AND                         |
+| priority_offset          | 0          | No       | For non production workloads we can +1 on the priorities                             |
 
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ avg(last_15m):max:kubernetes_state.deployment.replicas_desired{tag:xxx} by {clus
 
 Query:
 ```terraform
-avg(last_10m):sum:kubernetes.pods.running{tag:xxx} by {host} > 100.0
+min(last_10m):sum:kubernetes.pods.running{tag:xxx} by {host} > 100.0
 ```
 
 | variable                                  | default  | required | description                      |
@@ -300,6 +300,8 @@ avg(last_10m):sum:kubernetes.pods.running{tag:xxx} by {host} > 100.0
 | pod_count_per_node_high_enabled           | True     | No       |                                  |
 | pod_count_per_node_high_warning           | 90.0     | No       |                                  |
 | pod_count_per_node_high_critical          | 100.0    | No       |                                  |
+| pod_count_per_node_high_warning_recovery  | None     | No       |                                  |
+| pod_count_per_node_high_critical_recovery | None     | No       |                                  |
 | pod_count_per_node_high_evaluation_period | last_10m | No       |                                  |
 | pod_count_per_node_high_note              | ""       | No       |                                  |
 | pod_count_per_node_high_docs              | ""       | No       |                                  |
@@ -532,7 +534,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 Query:
 ```terraform
-max(last_5m):sum:kubernetes.cpu.capacity{tag:xxx} by {host,cluster_name} - sum:kubernetes.cpu.limits{tag:xxx} by {host,cluster_name} < -30
+max(last_5m):sum:kubernetes.cpu.capacity{tag:xxx} by {host,cluster_name} - sum:kubernetes.cpu.limits{tag:xxx} by {host,cluster_name} < ${-30}
 ```
 
 | variable                         | default                                  | required | description                                                                                          |

--- a/cpu-limits-low-perc-state.tf
+++ b/cpu-limits-low-perc-state.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_limits_low_perc_state" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available CPU for Limits in percentages Low"
   query            = "max(${var.cpu_limits_low_perc_state_evaluation_period}):( sum:kubernetes_state.container.cpu_limit{${local.cpu_limits_low_perc_state_filter}} by {host,cluster_name} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_limits_low_perc_state_filter}} by {host,cluster_name}) * 100 > ${var.cpu_limits_low_perc_state_critical}"

--- a/cpu-limits-low-perc-state.tf
+++ b/cpu-limits-low-perc-state.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "cpu_limits_low_perc_state" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available CPU for Limits in percentages Low"
   query            = "max(${var.cpu_limits_low_perc_state_evaluation_period}):( sum:kubernetes_state.container.cpu_limit{${local.cpu_limits_low_perc_state_filter}} by {host,cluster_name} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_limits_low_perc_state_filter}} by {host,cluster_name}) * 100 > ${var.cpu_limits_low_perc_state_critical}"

--- a/cpu-limits-low-perc-state.tf
+++ b/cpu-limits-low-perc-state.tf
@@ -19,7 +19,7 @@ module "cpu_limits_low_perc_state" {
   alerting_enabled   = var.cpu_limits_low_perc_state_alerting_enabled
   critical_threshold = var.cpu_limits_low_perc_state_critical
   warning_threshold  = var.cpu_limits_low_perc_state_warning
-  priority           = var.cpu_limits_low_perc_state_priority
+  priority           = min(var.cpu_limits_low_perc_state_priority + var.priority_offset, 5)
   docs               = var.cpu_limits_low_perc_state_docs
   note               = var.cpu_limits_low_perc_state_note
 

--- a/cpu-limits-low-perc.tf
+++ b/cpu-limits-low-perc.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "cpu_limits_low_perc" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available CPU for Limits in percentages Low"
   query            = "max(${var.cpu_limits_low_perc_evaluation_period}):( max:kubernetes.cpu.limits{${local.cpu_limits_low_perc_filter}} by {host,cluster_name} / max:kubernetes.cpu.capacity{${local.cpu_limits_low_perc_filter}} by {host,cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"

--- a/cpu-limits-low-perc.tf
+++ b/cpu-limits-low-perc.tf
@@ -10,7 +10,7 @@ module "cpu_limits_low_perc" {
   version = "0.7.1"
 
   name             = "Available CPU for Limits in percentages Low"
-  query            = "max(${var.cpu_limits_low_perc_evaluation_period}):(sum:kubernetes.cpu.requests{${local.cpu_limits_low_perc_filter}} by {host,cluster_name} / max:system.cpu.num_cores{${local.cpu_limits_low_perc_filter}} by {host,cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"
+  query            = "max(${var.cpu_limits_low_perc_evaluation_period}):(sum:kubernetes.cpu.limits{${local.cpu_limits_low_perc_filter}} by {host,cluster_name} / max:system.cpu.num_cores{${local.cpu_limits_low_perc_filter}} by {host,cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"
   alert_message    = "Kubernetes cluster cpu room for limits / percentage is too low"
   recovery_message = "Kubernetes cluster cpu limits / percentage has recovered"
 

--- a/cpu-limits-low-perc.tf
+++ b/cpu-limits-low-perc.tf
@@ -10,7 +10,7 @@ module "cpu_limits_low_perc" {
   version = "0.7.1"
 
   name             = "Available CPU for Limits in percentages Low"
-  query            = "max(${var.cpu_limits_low_perc_evaluation_period}):( max:kubernetes.cpu.limits{${local.cpu_limits_low_perc_filter}} by {host,cluster_name} / max:kubernetes.cpu.capacity{${local.cpu_limits_low_perc_filter}} by {host,cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"
+  query            = "max(${var.cpu_limits_low_perc_evaluation_period}):(sum:kubernetes.cpu.requests{${local.cpu_limits_low_perc_filter}} by {host,cluster_name} / max:system.cpu.num_cores{${local.cpu_limits_low_perc_filter}} by {host,cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"
   alert_message    = "Kubernetes cluster cpu room for limits / percentage is too low"
   recovery_message = "Kubernetes cluster cpu limits / percentage has recovered"
 
@@ -19,7 +19,7 @@ module "cpu_limits_low_perc" {
   alerting_enabled   = var.cpu_limits_low_perc_alerting_enabled
   critical_threshold = var.cpu_limits_low_perc_critical
   warning_threshold  = var.cpu_limits_low_perc_warning
-  priority           = var.cpu_limits_low_perc_priority
+  priority           = min(var.cpu_limits_low_perc_priority + var.priority_offset, 5)
   docs               = var.cpu_limits_low_perc_docs
   note               = var.cpu_limits_low_perc_note
 

--- a/cpu-limits-low-perc.tf
+++ b/cpu-limits-low-perc.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_limits_low_perc" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available CPU for Limits in percentages Low"
   query            = "max(${var.cpu_limits_low_perc_evaluation_period}):( max:kubernetes.cpu.limits{${local.cpu_limits_low_perc_filter}} by {host,cluster_name} / max:kubernetes.cpu.capacity{${local.cpu_limits_low_perc_filter}} by {host,cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"

--- a/cpu-limits-low.tf
+++ b/cpu-limits-low.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_limits_low" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available CPU for Limits Low"
   query            = "max(${var.cpu_limits_low_evaluation_period}):sum:kubernetes.cpu.capacity{${local.cpu_limits_low_filter}} by {host,cluster_name} - sum:kubernetes.cpu.limits{${local.cpu_limits_low_filter}} by {host,cluster_name} < ${var.cpu_limits_low_critical}"

--- a/cpu-limits-low.tf
+++ b/cpu-limits-low.tf
@@ -10,7 +10,7 @@ module "cpu_limits_low" {
   version = "0.7.1"
 
   name             = "Available CPU for Limits Low"
-  query            = "max(${var.cpu_limits_low_evaluation_period}):sum:kubernetes.cpu.capacity{${local.cpu_limits_low_filter}} by {host,cluster_name} - sum:kubernetes.cpu.limits{${local.cpu_limits_low_filter}} by {host,cluster_name} < ${var.cpu_limits_low_critical}"
+  query            = "min(${var.cpu_limits_low_evaluation_period}):max:system.cpu.num_cores{${local.cpu_limits_low_filter}} by {cluster_name,host} - sum:kubernetes.cpu.limits{${local.cpu_limits_low_filter}} by {cluster_name,host} < ${var.cpu_limits_low_critical}"
   alert_message    = "Kubernetes cluster cpu room for limits is too low"
   recovery_message = "Kubernetes cluster cpu limits has recovered"
 
@@ -19,7 +19,7 @@ module "cpu_limits_low" {
   alerting_enabled   = var.cpu_limits_low_alerting_enabled
   critical_threshold = var.cpu_limits_low_critical
   warning_threshold  = var.cpu_limits_low_warning
-  priority           = var.cpu_limits_low_priority
+  priority           = min(var.cpu_limits_low_priority + var.priority_offset, 5)
   docs               = var.cpu_limits_low_docs
   note               = var.cpu_limits_low_note
 

--- a/cpu-limits-low.tf
+++ b/cpu-limits-low.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "cpu_limits_low" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available CPU for Limits Low"
   query            = "max(${var.cpu_limits_low_evaluation_period}):sum:kubernetes.cpu.capacity{${local.cpu_limits_low_filter}} by {host,cluster_name} - sum:kubernetes.cpu.limits{${local.cpu_limits_low_filter}} by {host,cluster_name} < ${var.cpu_limits_low_critical}"

--- a/cpu-on-dns-pods-high.tf
+++ b/cpu-on-dns-pods-high.tf
@@ -8,7 +8,8 @@ locals {
 }
 
 module "cpu_on_dns_pods_high" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "CPU Usage on DNS pods is high"
   query            = "avg(${var.cpu_on_dns_pods_high_evaluation_period}):avg:docker.cpu.usage{${local.cpu_on_dns_pods_high_filter}} by {cluster_name,host,container_name} > ${var.cpu_on_dns_pods_high_critical}"

--- a/cpu-on-dns-pods-high.tf
+++ b/cpu-on-dns-pods-high.tf
@@ -21,7 +21,7 @@ module "cpu_on_dns_pods_high" {
   alerting_enabled   = var.cpu_on_dns_pods_high_alerting_enabled
   critical_threshold = var.cpu_on_dns_pods_high_critical
   warning_threshold  = var.cpu_on_dns_pods_high_warning
-  priority           = var.cpu_on_dns_pods_high_priority
+  priority           = min(var.cpu_on_dns_pods_high_priority + var.priority_offset, 5)
   docs               = var.cpu_on_dns_pods_high_docs
   note               = var.cpu_on_dns_pods_high_note
 

--- a/cpu-on-dns-pods-high.tf
+++ b/cpu-on-dns-pods-high.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 module "cpu_on_dns_pods_high" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "CPU Usage on DNS pods is high"
   query            = "avg(${var.cpu_on_dns_pods_high_evaluation_period}):avg:docker.cpu.usage{${local.cpu_on_dns_pods_high_filter}} by {cluster_name,host,container_name} > ${var.cpu_on_dns_pods_high_critical}"

--- a/cpu-requests-low-perc-state.tf
+++ b/cpu-requests-low-perc-state.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_requests_low_perc_state" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available CPU for requests in percentages Low"
   query            = "max(${var.cpu_requests_low_perc_state_evaluation_period}):( sum:kubernetes_state.container.cpu_requested{${local.cpu_requests_low_perc_state_filter}} by {host,cluster_name} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_requests_low_perc_state_filter}} by {host,cluster_name} ) * 100 > ${var.cpu_requests_low_perc_state_critical}"

--- a/cpu-requests-low-perc-state.tf
+++ b/cpu-requests-low-perc-state.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "cpu_requests_low_perc_state" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available CPU for requests in percentages Low"
   query            = "max(${var.cpu_requests_low_perc_state_evaluation_period}):( sum:kubernetes_state.container.cpu_requested{${local.cpu_requests_low_perc_state_filter}} by {host,cluster_name} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_requests_low_perc_state_filter}} by {host,cluster_name} ) * 100 > ${var.cpu_requests_low_perc_state_critical}"

--- a/cpu-requests-low-perc-state.tf
+++ b/cpu-requests-low-perc-state.tf
@@ -19,7 +19,7 @@ module "cpu_requests_low_perc_state" {
   alerting_enabled   = var.cpu_requests_low_perc_state_alerting_enabled
   critical_threshold = var.cpu_requests_low_perc_state_critical
   warning_threshold  = var.cpu_requests_low_perc_state_warning
-  priority           = var.cpu_requests_low_perc_state_priority
+  priority           = min(var.cpu_requests_low_perc_state_priority + var.priority_offset, 5)
   docs               = var.cpu_requests_low_perc_state_docs
   note               = var.cpu_requests_low_perc_state_note
 

--- a/cpu-requests-low-perc.tf
+++ b/cpu-requests-low-perc.tf
@@ -10,7 +10,7 @@ module "cpu_requests_low_perc" {
   version = "0.7.1"
 
   name             = "Available CPU for requests in percentages Low"
-  query            = "max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.cpu.requests{${local.cpu_requests_low_perc_filter}} by {host,cluster_name} / max:kubernetes.cpu.capacity{${local.cpu_requests_low_perc_filter}} by {host,cluster_name} ) * 100 > ${var.cpu_requests_low_perc_critical}"
+  query            = "max(${var.cpu_requests_low_perc_evaluation_period}):100 * sum:kubernetes.cpu.requests{${local.cpu_requests_low_perc_filter}} by {cluster_name,host} / max:system.cpu.num_cores{${local.cpu_requests_low_perc_filter}} by {cluster_name,host} > ${var.cpu_requests_low_perc_critical}"
   alert_message    = "Kubernetes cluster cpu room for requests / percentage is too low"
   recovery_message = "Kubernetes cluster cpu requests / percentage has recovered"
 
@@ -19,7 +19,7 @@ module "cpu_requests_low_perc" {
   alerting_enabled   = var.cpu_requests_low_perc_alerting_enabled
   critical_threshold = var.cpu_requests_low_perc_critical
   warning_threshold  = var.cpu_requests_low_perc_warning
-  priority           = var.cpu_requests_low_perc_priority
+  priority           = min(var.cpu_requests_low_perc_priority + var.priority_offset, 5)
   docs               = var.cpu_requests_low_perc_docs
   note               = var.cpu_requests_low_perc_note
 

--- a/cpu-requests-low-perc.tf
+++ b/cpu-requests-low-perc.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_requests_low_perc" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available CPU for requests in percentages Low"
   query            = "max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.cpu.requests{${local.cpu_requests_low_perc_filter}} by {host,cluster_name} / max:kubernetes.cpu.capacity{${local.cpu_requests_low_perc_filter}} by {host,cluster_name} ) * 100 > ${var.cpu_requests_low_perc_critical}"

--- a/cpu-requests-low-perc.tf
+++ b/cpu-requests-low-perc.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "cpu_requests_low_perc" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available CPU for requests in percentages Low"
   query            = "max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.cpu.requests{${local.cpu_requests_low_perc_filter}} by {host,cluster_name} / max:kubernetes.cpu.capacity{${local.cpu_requests_low_perc_filter}} by {host,cluster_name} ) * 100 > ${var.cpu_requests_low_perc_critical}"

--- a/cpu-requests-low.tf
+++ b/cpu-requests-low.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "cpu_requests_low" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available CPU for Requests Low"
   query            = "max(${var.cpu_requests_low_evaluation_period}):sum:kubernetes.cpu.capacity{${local.cpu_requests_low_filter}} by {host,cluster_name} - sum:kubernetes.cpu.requests{${local.cpu_requests_low_filter}} by {host,cluster_name} < ${var.cpu_requests_low_critical}"

--- a/cpu-requests-low.tf
+++ b/cpu-requests-low.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_requests_low" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available CPU for Requests Low"
   query            = "max(${var.cpu_requests_low_evaluation_period}):sum:kubernetes.cpu.capacity{${local.cpu_requests_low_filter}} by {host,cluster_name} - sum:kubernetes.cpu.requests{${local.cpu_requests_low_filter}} by {host,cluster_name} < ${var.cpu_requests_low_critical}"

--- a/cpu-requests-low.tf
+++ b/cpu-requests-low.tf
@@ -10,7 +10,7 @@ module "cpu_requests_low" {
   version = "0.7.1"
 
   name             = "Available CPU for Requests Low"
-  query            = "max(${var.cpu_requests_low_evaluation_period}):sum:kubernetes.cpu.capacity{${local.cpu_requests_low_filter}} by {host,cluster_name} - sum:kubernetes.cpu.requests{${local.cpu_requests_low_filter}} by {host,cluster_name} < ${var.cpu_requests_low_critical}"
+  query            = "max(${var.cpu_requests_low_evaluation_period}):max:system.cpu.num_cores{${local.cpu_requests_low_filter}} by {cluster_name,host} - sum:kubernetes.cpu.requests{${local.cpu_requests_low_filter}} by {cluster_name,host} < ${var.cpu_requests_low_critical}"
   alert_message    = "Kubernetes cluster cpu room for requests is too low"
   recovery_message = "Kubernetes cluster cpu requests has recovered"
 
@@ -19,7 +19,7 @@ module "cpu_requests_low" {
   alerting_enabled   = var.cpu_requests_low_alerting_enabled
   critical_threshold = var.cpu_requests_low_critical
   warning_threshold  = var.cpu_requests_low_warning
-  priority           = var.cpu_requests_low_priority
+  priority           = min(var.cpu_requests_low_priority + var.priority_offset, 5)
   docs               = var.cpu_requests_low_docs
   note               = var.cpu_requests_low_note
 

--- a/daemonset-incomplete.tf
+++ b/daemonset-incomplete.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "daemonset_incomplete" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Daemonset Incomplete"
   query            = "min(${var.daemonset_incomplete_evaluation_period}):max:kubernetes_state.daemonset.scheduled{${local.daemonset_incomplete_filter}} by {daemonset,cluster_name} - min:kubernetes_state.daemonset.ready{${local.daemonset_incomplete_filter}} by {daemonset,cluster_name} > 0"

--- a/daemonset-incomplete.tf
+++ b/daemonset-incomplete.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "daemonset_incomplete" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Daemonset Incomplete"
   query            = "min(${var.daemonset_incomplete_evaluation_period}):max:kubernetes_state.daemonset.scheduled{${local.daemonset_incomplete_filter}} by {daemonset,cluster_name} - min:kubernetes_state.daemonset.ready{${local.daemonset_incomplete_filter}} by {daemonset,cluster_name} > 0"

--- a/daemonset-incomplete.tf
+++ b/daemonset-incomplete.tf
@@ -19,7 +19,7 @@ module "daemonset_incomplete" {
   alerting_enabled   = var.daemonset_incomplete_alerting_enabled
   critical_threshold = var.daemonset_incomplete_critical
   # no warning threshold for this monitor
-  priority = var.daemonset_incomplete_priority
+  priority = min(var.daemonset_incomplete_priority + var.priority_offset, 5)
   docs     = var.daemonset_incomplete_docs
   note     = var.daemonset_incomplete_note
 

--- a/datadog-agent.tf
+++ b/datadog-agent.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "datadog_agent" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Datadog agent not running"
   query            = "avg(${var.datadog_agent_evaluation_period}):avg:datadog.agent.running{${local.datadog_agent_filter}} by {host,cluster_name} < 1"

--- a/datadog-agent.tf
+++ b/datadog-agent.tf
@@ -19,7 +19,7 @@ module "datadog_agent" {
   alerting_enabled   = var.datadog_agent_alerting_enabled
   critical_threshold = 1
   # no warning threshold for this monitor
-  priority = var.datadog_agent_priority
+  priority = min(var.datadog_agent_priority + var.priority_offset, 5)
   docs     = var.datadog_agent_docs
   note     = var.datadog_agent_note
 

--- a/datadog-agent.tf
+++ b/datadog-agent.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "datadog_agent" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Datadog agent not running"
   query            = "avg(${var.datadog_agent_evaluation_period}):avg:datadog.agent.running{${local.datadog_agent_filter}} by {host,cluster_name} < 1"

--- a/deploy-desired-vs-status.tf
+++ b/deploy-desired-vs-status.tf
@@ -19,7 +19,7 @@ module "deploy_desired_vs_status" {
   alerting_enabled   = var.deploy_desired_vs_status_alerting_enabled
   critical_threshold = var.deploy_desired_vs_status_critical
   warning_threshold  = var.deploy_desired_vs_status_warning
-  priority           = var.deploy_desired_vs_status_priority
+  priority           = min(var.deploy_desired_vs_status_priority + var.priority_offset, 5)
   docs               = var.deploy_desired_vs_status_docs
   note               = var.deploy_desired_vs_status_note
 

--- a/deploy-desired-vs-status.tf
+++ b/deploy-desired-vs-status.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "deploy_desired_vs_status" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Desired pods vs current pods (Deployments)"
   query            = "avg(${var.deploy_desired_vs_status_evaluation_period}):max:kubernetes_state.deployment.replicas_desired{${local.deploy_desired_vs_status_filter}} by {cluster_name,host} - max:kubernetes_state.deployment.replicas{${local.deploy_desired_vs_status_filter}} by {cluster_name,host} > ${var.deploy_desired_vs_status_critical}"

--- a/deploy-desired-vs-status.tf
+++ b/deploy-desired-vs-status.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "deploy_desired_vs_status" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Desired pods vs current pods (Deployments)"
   query            = "avg(${var.deploy_desired_vs_status_evaluation_period}):max:kubernetes_state.deployment.replicas_desired{${local.deploy_desired_vs_status_filter}} by {cluster_name,host} - max:kubernetes_state.deployment.replicas{${local.deploy_desired_vs_status_filter}} by {cluster_name,host} > ${var.deploy_desired_vs_status_critical}"

--- a/hpa-status.tf
+++ b/hpa-status.tf
@@ -19,7 +19,7 @@ module "hpa_status" {
   alerting_enabled   = var.hpa_status_alerting_enabled
   critical_threshold = 1
   # No warning_threshold possible
-  priority = var.hpa_status_priority
+  priority = min(var.hpa_status_priority + var.priority_offset, 5)
   docs     = var.hpa_status_docs
   note     = var.hpa_status_note
 

--- a/hpa-status.tf
+++ b/hpa-status.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "hpa_status" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "HPA Status not OK"
   query            = "avg(${var.hpa_status_evaluation_period}):avg:kubernetes_state.hpa.condition{${local.hpa_status_filter}} by {hpa,kube_namespace,status,condition} < 1"

--- a/hpa-status.tf
+++ b/hpa-status.tf
@@ -5,7 +5,8 @@ locals {
 }
 
 module "hpa_status" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "HPA Status not OK"
   query            = "avg(${var.hpa_status_evaluation_period}):avg:kubernetes_state.hpa.condition{${local.hpa_status_filter}} by {hpa,kube_namespace,status,condition} < 1"

--- a/memory-limits-low-perc-state.tf
+++ b/memory-limits-low-perc-state.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "memory_limits_low_perc_state" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available Memory for Limits in percentage Low"
   query            = "max(${var.memory_limits_low_perc_state_evaluation_period}):( sum:kubernetes_state.container.memory_limit{${local.memory_limits_low_perc_state_filter}} by {host,cluster_name} / sum:kubernetes_state.node.memory_allocatable{${local.memory_limits_low_perc_state_filter}} by {host,cluster_name}) * 100 > ${var.memory_limits_low_perc_state_critical}"

--- a/memory-limits-low-perc-state.tf
+++ b/memory-limits-low-perc-state.tf
@@ -19,7 +19,7 @@ module "memory_limits_low_perc_state" {
   alerting_enabled   = var.memory_limits_low_perc_state_alerting_enabled
   critical_threshold = var.memory_limits_low_perc_state_critical
   warning_threshold  = var.memory_limits_low_perc_state_warning
-  priority           = var.memory_limits_low_perc_state_priority
+  priority           = min(var.memory_limits_low_perc_state_priority + var.priority_offset, 5)
   docs               = var.memory_limits_low_perc_state_docs
   note               = var.memory_limits_low_perc_state_note
 

--- a/memory-limits-low-perc-state.tf
+++ b/memory-limits-low-perc-state.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_limits_low_perc_state" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available Memory for Limits in percentage Low"
   query            = "max(${var.memory_limits_low_perc_state_evaluation_period}):( sum:kubernetes_state.container.memory_limit{${local.memory_limits_low_perc_state_filter}} by {host,cluster_name} / sum:kubernetes_state.node.memory_allocatable{${local.memory_limits_low_perc_state_filter}} by {host,cluster_name}) * 100 > ${var.memory_limits_low_perc_state_critical}"

--- a/memory-limits-low-perc.tf
+++ b/memory-limits-low-perc.tf
@@ -10,7 +10,7 @@ module "memory_limits_low_perc" {
   version = "0.7.1"
 
   name             = "Available Memory for Limits in percentage Low"
-  query            = "max(${var.memory_limits_low_perc_evaluation_period}):( max:kubernetes.memory.limits{${local.memory_limits_low_perc_filter}}  by {host,cluster_name}/ max:kubernetes.memory.capacity{${local.memory_limits_low_perc_filter}} by {host,cluster_name}) * 100 > ${var.memory_limits_low_perc_critical}"
+  query            = "max(${var.memory_limits_low_perc_evaluation_period}):( max:kubernetes.memory.limits{${local.memory_limits_low_perc_filter}}  by {host,cluster_name}/ max:system.mem.total{${local.memory_limits_low_perc_filter}} by {host,cluster_name}) * 100 > ${var.memory_limits_low_perc_critical}"
   alert_message    = "Kubernetes cluster memory room for limits in percentage is too low"
   recovery_message = "Kubernetes cluster memory limits in percentage has recovered"
 
@@ -19,7 +19,7 @@ module "memory_limits_low_perc" {
   alerting_enabled   = var.memory_limits_low_perc_alerting_enabled
   critical_threshold = var.memory_limits_low_perc_critical
   warning_threshold  = var.memory_limits_low_perc_warning
-  priority           = var.memory_limits_low_perc_priority
+  priority           = min(var.memory_limits_low_perc_priority + var.priority_offset, 5)
   docs               = var.memory_limits_low_perc_docs
   note               = var.memory_limits_low_perc_note
 

--- a/memory-limits-low-perc.tf
+++ b/memory-limits-low-perc.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "memory_limits_low_perc" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available Memory for Limits in percentage Low"
   query            = "max(${var.memory_limits_low_perc_evaluation_period}):( max:kubernetes.memory.limits{${local.memory_limits_low_perc_filter}}  by {host,cluster_name}/ max:kubernetes.memory.capacity{${local.memory_limits_low_perc_filter}} by {host,cluster_name}) * 100 > ${var.memory_limits_low_perc_critical}"

--- a/memory-limits-low-perc.tf
+++ b/memory-limits-low-perc.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_limits_low_perc" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available Memory for Limits in percentage Low"
   query            = "max(${var.memory_limits_low_perc_evaluation_period}):( max:kubernetes.memory.limits{${local.memory_limits_low_perc_filter}}  by {host,cluster_name}/ max:kubernetes.memory.capacity{${local.memory_limits_low_perc_filter}} by {host,cluster_name}) * 100 > ${var.memory_limits_low_perc_critical}"

--- a/memory-limits-low.tf
+++ b/memory-limits-low.tf
@@ -10,7 +10,7 @@ module "memory_limits_low" {
   version = "0.7.1"
 
   name             = "Available Memory for Limits Low"
-  query            = "avg(${var.memory_limits_low_evaluation_period}):max:kubernetes.memory.capacity{${local.memory_limits_low_filter}} by {host,cluster_name} - max:kubernetes.memory.limits{${local.memory_limits_low_filter}} by {host,cluster_name} < ${var.memory_limits_low_critical}"
+  query            = "avg(${var.memory_limits_low_evaluation_period}):max:system.mem.total{${local.memory_limits_low_filter}} by {host,cluster_name} - max:kubernetes.memory.limits{${local.memory_limits_low_filter}} by {host,cluster_name} < ${var.memory_limits_low_critical}"
   alert_message    = "Kubernetes cluster memory room for limits is too low"
   recovery_message = "Kubernetes cluster memory limits has recovered"
 
@@ -19,7 +19,7 @@ module "memory_limits_low" {
   alerting_enabled   = var.memory_limits_low_alerting_enabled
   critical_threshold = var.memory_limits_low_critical
   warning_threshold  = var.memory_limits_low_warning
-  priority           = var.memory_limits_low_priority
+  priority           = min(var.memory_limits_low_priority + var.priority_offset, 5)
   docs               = var.memory_limits_low_docs
   note               = var.memory_limits_low_note
 

--- a/memory-limits-low.tf
+++ b/memory-limits-low.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "memory_limits_low" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available Memory for Limits Low"
   query            = "avg(${var.memory_limits_low_evaluation_period}):max:kubernetes.memory.capacity{${local.memory_limits_low_filter}} by {host,cluster_name} - max:kubernetes.memory.limits{${local.memory_limits_low_filter}} by {host,cluster_name} < ${var.memory_limits_low_critical}"

--- a/memory-limits-low.tf
+++ b/memory-limits-low.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_limits_low" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available Memory for Limits Low"
   query            = "avg(${var.memory_limits_low_evaluation_period}):max:kubernetes.memory.capacity{${local.memory_limits_low_filter}} by {host,cluster_name} - max:kubernetes.memory.limits{${local.memory_limits_low_filter}} by {host,cluster_name} < ${var.memory_limits_low_critical}"

--- a/memory-requests-low-perc.tf
+++ b/memory-requests-low-perc.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_requests_low_perc" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available Memory for Requests in percentage Low"
   query            = "max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.memory.requests{${local.cpu_requests_low_perc_filter}} / max:kubernetes.memory.capacity{${local.cpu_requests_low_perc_filter}} ) * 100 > ${var.cpu_requests_low_perc_critical}"

--- a/memory-requests-low-perc.tf
+++ b/memory-requests-low-perc.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "memory_requests_low_perc" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available Memory for Requests in percentage Low"
   query            = "max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.memory.requests{${local.cpu_requests_low_perc_filter}} / max:kubernetes.memory.capacity{${local.cpu_requests_low_perc_filter}} ) * 100 > ${var.cpu_requests_low_perc_critical}"

--- a/memory-requests-low-perc.tf
+++ b/memory-requests-low-perc.tf
@@ -10,7 +10,7 @@ module "memory_requests_low_perc" {
   version = "0.7.1"
 
   name             = "Available Memory for Requests in percentage Low"
-  query            = "max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.memory.requests{${local.cpu_requests_low_perc_filter}} / max:kubernetes.memory.capacity{${local.cpu_requests_low_perc_filter}} ) * 100 > ${var.cpu_requests_low_perc_critical}"
+  query            = "max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.memory.requests{${local.cpu_requests_low_perc_filter}} / max:system.mem.total{${local.cpu_requests_low_perc_filter}} ) * 100 > ${var.cpu_requests_low_perc_critical}"
   alert_message    = "Kubernetes cluster memory room for Requests in percentage is too low"
   recovery_message = "Kubernetes cluster memory Requests in percentage has recovered"
 
@@ -19,7 +19,7 @@ module "memory_requests_low_perc" {
   alerting_enabled   = var.memory_requests_low_perc_alerting_enabled
   critical_threshold = var.memory_requests_low_perc_critical
   warning_threshold  = var.memory_requests_low_perc_warning
-  priority           = var.memory_requests_low_perc_priority
+  priority           = min(var.memory_requests_low_perc_priority + var.priority_offset, 5)
   docs               = var.memory_requests_low_perc_docs
   note               = var.memory_requests_low_perc_note
 

--- a/memory-requests-low-state-perc.tf
+++ b/memory-requests-low-state-perc.tf
@@ -19,7 +19,7 @@ module "memory_requests_low_perc_state" {
   alerting_enabled   = var.memory_requests_low_perc_state_alerting_enabled
   critical_threshold = var.memory_requests_low_perc_state_critical
   warning_threshold  = var.memory_requests_low_perc_state_warning
-  priority           = var.memory_requests_low_perc_state_priority
+  priority           = min(var.memory_requests_low_perc_state_priority + var.priority_offset, 5)
   docs               = var.memory_requests_low_perc_state_docs
   note               = var.memory_requests_low_perc_state_note
 

--- a/memory-requests-low-state-perc.tf
+++ b/memory-requests-low-state-perc.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "memory_requests_low_perc_state" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available Memory for Requests in percentage Low"
   query            = "max(${var.memory_requests_low_perc_state_evaluation_period}):( max:kubernetes_state.container.memory_requested{${local.memory_requests_low_perc_state_filter}} / max:kubernetes_state.node.memory_allocatable{${local.memory_requests_low_perc_state_filter}} ) * 100 > ${var.memory_requests_low_perc_state_critical}"

--- a/memory-requests-low-state-perc.tf
+++ b/memory-requests-low-state-perc.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_requests_low_perc_state" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available Memory for Requests in percentage Low"
   query            = "max(${var.memory_requests_low_perc_state_evaluation_period}):( max:kubernetes_state.container.memory_requested{${local.memory_requests_low_perc_state_filter}} / max:kubernetes_state.node.memory_allocatable{${local.memory_requests_low_perc_state_filter}} ) * 100 > ${var.memory_requests_low_perc_state_critical}"

--- a/memory-requests-low.tf
+++ b/memory-requests-low.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "memory_requests_low" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Available Memory for Requests Low"
   query            = "avg(${var.memory_requests_low_evaluation_period}):max:kubernetes.memory.capacity{${local.memory_requests_low_filter}} by {host,cluster_name} - max:kubernetes.memory.requests{${local.memory_requests_low_filter}} by {host,cluster_name} < ${var.memory_requests_low_critical}"

--- a/memory-requests-low.tf
+++ b/memory-requests-low.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_requests_low" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Available Memory for Requests Low"
   query            = "avg(${var.memory_requests_low_evaluation_period}):max:kubernetes.memory.capacity{${local.memory_requests_low_filter}} by {host,cluster_name} - max:kubernetes.memory.requests{${local.memory_requests_low_filter}} by {host,cluster_name} < ${var.memory_requests_low_critical}"

--- a/memory-requests-low.tf
+++ b/memory-requests-low.tf
@@ -10,7 +10,7 @@ module "memory_requests_low" {
   version = "0.7.1"
 
   name             = "Available Memory for Requests Low"
-  query            = "avg(${var.memory_requests_low_evaluation_period}):max:kubernetes.memory.capacity{${local.memory_requests_low_filter}} by {host,cluster_name} - max:kubernetes.memory.requests{${local.memory_requests_low_filter}} by {host,cluster_name} < ${var.memory_requests_low_critical}"
+  query            = "avg(${var.memory_requests_low_evaluation_period}):max:system.mem.total{${local.memory_requests_low_filter}} by {host,cluster_name} - max:kubernetes.memory.requests{${local.memory_requests_low_filter}} by {host,cluster_name} < ${var.memory_requests_low_critical}"
   alert_message    = "Total memory available for requests on {{ host }} is low ({{value}})"
   recovery_message = "Total memory available for requests on {{ host }} has recovered ({{value}})"
 
@@ -19,7 +19,7 @@ module "memory_requests_low" {
   alerting_enabled   = var.memory_requests_low_alerting_enabled
   critical_threshold = var.memory_requests_low_critical
   warning_threshold  = var.memory_requests_low_warning
-  priority           = var.memory_requests_low_priority
+  priority           = min(var.memory_requests_low_priority + var.priority_offset, 5)
   docs               = var.memory_requests_low_docs
   note               = var.memory_requests_low_note
 

--- a/network-unavailable.tf
+++ b/network-unavailable.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "network_unavailable" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Nodes with Network Unavailable"
   query            = "avg(${var.network_unavailable_evaluation_period}):max:kubernetes_state.nodes.by_condition{${local.network_unavailable_filter} AND condition:networkunavailable AND (status:true OR status:unknown)} by {cluster_name,host} > ${var.network_unavailable_critical}"

--- a/network-unavailable.tf
+++ b/network-unavailable.tf
@@ -19,7 +19,7 @@ module "network_unavailable" {
   alerting_enabled   = var.network_unavailable_alerting_enabled
   critical_threshold = var.network_unavailable_critical
   # no warning threshold for this monitor
-  priority = var.network_unavailable_priority
+  priority = min(var.network_unavailable_priority + var.priority_offset, 5)
   docs     = var.network_unavailable_docs
   note     = var.network_unavailable_note
 

--- a/network-unavailable.tf
+++ b/network-unavailable.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "network_unavailable" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Nodes with Network Unavailable"
   query            = "avg(${var.network_unavailable_evaluation_period}):max:kubernetes_state.nodes.by_condition{${local.network_unavailable_filter} AND condition:networkunavailable AND (status:true OR status:unknown)} by {cluster_name,host} > ${var.network_unavailable_critical}"

--- a/node-diskpressure.tf
+++ b/node-diskpressure.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "node_diskpressure" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Nodes with Diskpressure"
   query            = "avg(${var.node_diskpressure_evaluation_period}):max:kubernetes_state.nodes.by_condition{${local.node_diskpressure_filter} AND condition:diskpressure AND (status:true OR status:unknown)} by {cluster_name,host} > ${var.node_diskpressure_critical}"

--- a/node-diskpressure.tf
+++ b/node-diskpressure.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "node_diskpressure" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Nodes with Diskpressure"
   query            = "avg(${var.node_diskpressure_evaluation_period}):max:kubernetes_state.nodes.by_condition{${local.node_diskpressure_filter} AND condition:diskpressure AND (status:true OR status:unknown)} by {cluster_name,host} > ${var.node_diskpressure_critical}"

--- a/node-diskpressure.tf
+++ b/node-diskpressure.tf
@@ -19,7 +19,7 @@ module "node_diskpressure" {
   alerting_enabled   = var.node_diskpressure_alerting_enabled
   critical_threshold = var.node_diskpressure_critical
   # no warning threshold for this monitor
-  priority = var.node_diskpressure_priority
+  priority = min(var.node_diskpressure_priority + var.priority_offset, 5)
   docs     = var.node_diskpressure_docs
   note     = var.node_diskpressure_note
 

--- a/node-memory-used-percent.tf
+++ b/node-memory-used-percent.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "node_memory_used_percent" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Memory Used Percent"
   query            = "avg(${var.node_memory_used_percent_evaluation_period}):( 100 * max:kubernetes.memory.usage{${local.node_memory_used_percent_filter}} by {host,cluster_name} ) / max:kubernetes.memory.capacity{${local.node_memory_used_percent_filter}} by {host,cluster_name} > ${var.node_memory_used_percent_critical}"

--- a/node-memory-used-percent.tf
+++ b/node-memory-used-percent.tf
@@ -10,7 +10,7 @@ module "node_memory_used_percent" {
   version = "0.7.1"
 
   name             = "Memory Used Percent"
-  query            = "avg(${var.node_memory_used_percent_evaluation_period}):( 100 * max:kubernetes.memory.usage{${local.node_memory_used_percent_filter}} by {host,cluster_name} ) / max:kubernetes.memory.capacity{${local.node_memory_used_percent_filter}} by {host,cluster_name} > ${var.node_memory_used_percent_critical}"
+  query            = "avg(${var.node_memory_used_percent_evaluation_period}):( 100 * max:kubernetes.memory.usage{${local.node_memory_used_percent_filter}} by {host,cluster_name} ) / max:system.mem.total{${local.node_memory_used_percent_filter}} by {host,cluster_name} > ${var.node_memory_used_percent_critical}"
   alert_message    = "Available memory on ${var.service} Node {{host.name}} has dropped below {{threshold}} and has {{value}}% available"
   recovery_message = "Available memory on ${var.service} Node {{host.name}} has recovered {{value}}%"
 
@@ -19,7 +19,7 @@ module "node_memory_used_percent" {
   alerting_enabled   = var.node_memory_used_percent_alerting_enabled
   critical_threshold = var.node_memory_used_percent_critical
   warning_threshold  = var.node_memory_used_percent_warning
-  priority           = var.node_memory_used_percent_priority
+  priority           = min(var.node_memory_used_percent_priority + var.priority_offset, 5)
   docs               = var.node_memory_used_percent_docs
   note               = var.node_memory_used_percent_note
 

--- a/node-memory-used-percent.tf
+++ b/node-memory-used-percent.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "node_memory_used_percent" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Memory Used Percent"
   query            = "avg(${var.node_memory_used_percent_evaluation_period}):( 100 * max:kubernetes.memory.usage{${local.node_memory_used_percent_filter}} by {host,cluster_name} ) / max:kubernetes.memory.capacity{${local.node_memory_used_percent_filter}} by {host,cluster_name} > ${var.node_memory_used_percent_critical}"

--- a/node-memorypressure.tf
+++ b/node-memorypressure.tf
@@ -19,7 +19,7 @@ module "node_memorypressure" {
   alerting_enabled   = var.node_memorypressure_alerting_enabled
   critical_threshold = var.node_memorypressure_critical
   # no warning threshold for this monitor
-  priority = var.node_memorypressure_priority
+  priority = min(var.node_memorypressure_priority + var.priority_offset, 5)
   docs     = var.node_memorypressure_docs
   note     = var.node_memorypressure_note
 

--- a/node-memorypressure.tf
+++ b/node-memorypressure.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "node_memorypressure" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Nodes with Memorypressure"
   query            = "avg(${var.node_memorypressure_evaluation_period}):max:kubernetes_state.nodes.by_condition{${local.node_memorypressure_filter} AND condition:memorypressure AND (status:true OR status:unknown)} by {cluster_name,host} > ${var.node_memorypressure_critical}"

--- a/node-memorypressure.tf
+++ b/node-memorypressure.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "node_memorypressure" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Nodes with Memorypressure"
   query            = "avg(${var.node_memorypressure_evaluation_period}):max:kubernetes_state.nodes.by_condition{${local.node_memorypressure_filter} AND condition:memorypressure AND (status:true OR status:unknown)} by {cluster_name,host} > ${var.node_memorypressure_critical}"

--- a/node-ready.tf
+++ b/node-ready.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "node_ready" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Node Not Ready"
   query            = "avg(${var.node_ready_evaluation_period}):count_nonzero(sum:kubernetes_state.nodes.by_condition{${local.node_ready_filter} AND (NOT condition:ready) AND (status:true OR status:unknown)} by {cluster_name,host}) > ${var.node_ready_critical}"

--- a/node-ready.tf
+++ b/node-ready.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "node_ready" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Node Not Ready"
   query            = "avg(${var.node_ready_evaluation_period}):count_nonzero(sum:kubernetes_state.nodes.by_condition{${local.node_ready_filter} AND (NOT condition:ready) AND (status:true OR status:unknown)} by {cluster_name,host}) > ${var.node_ready_critical}"

--- a/node-ready.tf
+++ b/node-ready.tf
@@ -19,7 +19,7 @@ module "node_ready" {
   alerting_enabled   = var.node_ready_alerting_enabled
   critical_threshold = var.node_ready_critical
   # no warning threshold for this monitor
-  priority = var.node_ready_priority
+  priority = min(var.node_ready_priority + var.priority_offset, 5)
   docs     = var.node_ready_docs
   note     = var.node_ready_note
 

--- a/node-status.tf
+++ b/node-status.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "node_status" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name                = "Node Status not OK"
   query               = "avg(${var.node_status_evaluation_period}):avg:kubernetes_state.node.status{${local.node_status_filter}} by {cluster_name,node} < 1"

--- a/node-status.tf
+++ b/node-status.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "node_status" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name                = "Node Status not OK"
   query               = "avg(${var.node_status_evaluation_period}):avg:kubernetes_state.node.status{${local.node_status_filter}} by {cluster_name,node} < 1"

--- a/node-status.tf
+++ b/node-status.tf
@@ -20,7 +20,7 @@ module "node_status" {
   alerting_enabled   = var.node_status_alerting_enabled
   critical_threshold = 1
   # No warning possible for status that is either 0 or 1
-  priority = var.node_status_priority
+  priority = min(var.node_status_priority + var.priority_offset, 5)
   docs     = var.node_status_docs
   note     = var.node_status_note
 

--- a/persistent-volumes.tf
+++ b/persistent-volumes.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "persistent_volumes_low" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Failed Persistent Volume Claims"
   query            = "avg(${var.persistent_volumes_evaluation_period}):max:kubernetes_state.persistentvolumes.by_phase{${local.persistent_volumes_filter} AND phase:failed} > ${var.persistent_volumes_critical}"

--- a/persistent-volumes.tf
+++ b/persistent-volumes.tf
@@ -19,7 +19,7 @@ module "persistent_volumes_low" {
   alerting_enabled   = var.persistent_volumes_alerting_enabled
   critical_threshold = var.persistent_volumes_critical
   warning_threshold  = var.persistent_volumes_warning
-  priority           = var.persistent_volumes_priority
+  priority           = min(var.persistent_volumes_priority + var.priority_offset, 5)
   docs               = var.persistent_volumes_docs
   note               = var.persistent_volumes_note
 

--- a/persistent-volumes.tf
+++ b/persistent-volumes.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "persistent_volumes_low" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Failed Persistent Volume Claims"
   query            = "avg(${var.persistent_volumes_evaluation_period}):max:kubernetes_state.persistentvolumes.by_phase{${local.persistent_volumes_filter} AND phase:failed} > ${var.persistent_volumes_critical}"

--- a/pid-pressure.tf
+++ b/pid-pressure.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "pid_pressure" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Nodes with PID Pressure"
   query            = "avg(${var.pid_pressure_evaluation_period}):max:kubernetes_state.nodes.by_condition{${local.pid_pressure_filter} AND condition:pidpressure AND (status:true OR status:unknown)} by {cluster_name,host} > ${var.pid_pressure_critical}"

--- a/pid-pressure.tf
+++ b/pid-pressure.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pid_pressure" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Nodes with PID Pressure"
   query            = "avg(${var.pid_pressure_evaluation_period}):max:kubernetes_state.nodes.by_condition{${local.pid_pressure_filter} AND condition:pidpressure AND (status:true OR status:unknown)} by {cluster_name,host} > ${var.pid_pressure_critical}"

--- a/pid-pressure.tf
+++ b/pid-pressure.tf
@@ -19,7 +19,7 @@ module "pid_pressure" {
   alerting_enabled   = var.pid_pressure_alerting_enabled
   critical_threshold = var.pid_pressure_critical
   # no warning threshold for this monitor
-  priority = var.pid_pressure_priority
+  priority = min(var.pid_pressure_priority + var.priority_offset, 5)
   docs     = var.pid_pressure_docs
   note     = var.pid_pressure_note
 

--- a/pod-count-per-node-high-variables.tf
+++ b/pod-count-per-node-high-variables.tf
@@ -13,6 +13,16 @@ variable "pod_count_per_node_high_critical" {
   default = 100.0
 }
 
+variable "pod_count_per_node_high_warning_recovery" {
+  type    = number
+  default = null
+}
+
+variable "pod_count_per_node_high_critical_recovery" {
+  type    = number
+  default = null
+}
+
 variable "pod_count_per_node_high_evaluation_period" {
   type    = string
   default = "last_10m"

--- a/pod-count-per-node-high.tf
+++ b/pod-count-per-node-high.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "pod_count_per_node_high" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name  = "Pod count per node high"
   query = "min(${var.pod_count_per_node_high_evaluation_period}):sum:kubernetes.pods.running{${local.pod_count_per_node_high_filter}} by {host} > ${var.pod_count_per_node_high_critical}"

--- a/pod-count-per-node-high.tf
+++ b/pod-count-per-node-high.tf
@@ -6,10 +6,10 @@ locals {
 }
 
 module "pod_count_per_node_high" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name  = "Pod count per node high"
-  query = "avg(${var.pod_count_per_node_high_evaluation_period}):sum:kubernetes.pods.running{${local.pod_count_per_node_high_filter}} by {host} > ${var.pod_count_per_node_high_critical}"
+  query = "min(${var.pod_count_per_node_high_evaluation_period}):sum:kubernetes.pods.running{${local.pod_count_per_node_high_filter}} by {host} > ${var.pod_count_per_node_high_critical}"
 
   # alert specific configuration
   require_full_window = false
@@ -17,13 +17,14 @@ module "pod_count_per_node_high" {
   recovery_message    = "Pod count per node high ({{ value }}) in {{ service }} has recovered"
 
   # monitor level vars
-  enabled            = var.pod_count_per_node_high_enabled
-  alerting_enabled   = var.pod_count_per_node_high_alerting_enabled
-  warning_threshold  = var.pod_count_per_node_high_warning
-  critical_threshold = var.pod_count_per_node_high_critical
-  priority           = var.pod_count_per_node_high_priority
-  docs               = var.pod_count_per_node_high_docs
-  note               = var.pod_count_per_node_high_note
+  enabled                     = var.pod_count_per_node_high_enabled
+  alerting_enabled            = var.pod_count_per_node_high_alerting_enabled
+  warning_threshold           = var.pod_count_per_node_high_warning
+  warning_recovery_threshold  = var.pod_count_per_node_high_warning_recovery
+  critical_recovery_threshold = var.pod_count_per_node_high_critical_recovery
+  priority                    = var.pod_count_per_node_high_priority
+  docs                        = var.pod_count_per_node_high_docs
+  note                        = var.pod_count_per_node_high_note
 
   # module level vars
   env                  = var.env

--- a/pod-count-per-node-high.tf
+++ b/pod-count-per-node-high.tf
@@ -17,14 +17,14 @@ module "pod_count_per_node_high" {
   recovery_message    = "Pod count per node high ({{ value }}) in {{ service }} has recovered"
 
   # monitor level vars
-  enabled                     = var.pod_count_per_node_high_enabled
-  alerting_enabled            = var.pod_count_per_node_high_alerting_enabled
-  warning_threshold           = var.pod_count_per_node_high_warning
-  warning_recovery_threshold  = var.pod_count_per_node_high_warning_recovery
-  critical_recovery_threshold = var.pod_count_per_node_high_critical_recovery
-  priority                    = var.pod_count_per_node_high_priority
-  docs                        = var.pod_count_per_node_high_docs
-  note                        = var.pod_count_per_node_high_note
+  enabled           = var.pod_count_per_node_high_enabled
+  alerting_enabled  = var.pod_count_per_node_high_alerting_enabled
+  warning_threshold = var.pod_count_per_node_high_warning
+  warning_recovery  = var.pod_count_per_node_high_warning_recovery
+  critical_recovery = var.pod_count_per_node_high_critical_recovery
+  priority          = var.pod_count_per_node_high_priority
+  docs              = var.pod_count_per_node_high_docs
+  note              = var.pod_count_per_node_high_note
 
   # module level vars
   env                  = var.env

--- a/pod-count-per-node-high.tf
+++ b/pod-count-per-node-high.tf
@@ -17,14 +17,15 @@ module "pod_count_per_node_high" {
   recovery_message    = "Pod count per node high ({{ value }}) in {{ service }} has recovered"
 
   # monitor level vars
-  enabled           = var.pod_count_per_node_high_enabled
-  alerting_enabled  = var.pod_count_per_node_high_alerting_enabled
-  warning_threshold = var.pod_count_per_node_high_warning
-  warning_recovery  = var.pod_count_per_node_high_warning_recovery
-  critical_recovery = var.pod_count_per_node_high_critical_recovery
-  priority          = var.pod_count_per_node_high_priority
-  docs              = var.pod_count_per_node_high_docs
-  note              = var.pod_count_per_node_high_note
+  enabled            = var.pod_count_per_node_high_enabled
+  alerting_enabled   = var.pod_count_per_node_high_alerting_enabled
+  critical_threshold = var.pod_count_per_node_high_critical
+  critical_recovery  = var.pod_count_per_node_high_critical_recovery
+  warning_threshold  = var.pod_count_per_node_high_warning
+  warning_recovery   = var.pod_count_per_node_high_warning_recovery
+  priority           = var.pod_count_per_node_high_priority
+  docs               = var.pod_count_per_node_high_docs
+  note               = var.pod_count_per_node_high_note
 
   # module level vars
   env                  = var.env

--- a/pod-count-per-node-high.tf
+++ b/pod-count-per-node-high.tf
@@ -24,7 +24,7 @@ module "pod_count_per_node_high" {
   critical_recovery  = var.pod_count_per_node_high_critical_recovery
   warning_threshold  = var.pod_count_per_node_high_warning
   warning_recovery   = var.pod_count_per_node_high_warning_recovery
-  priority           = var.pod_count_per_node_high_priority
+  priority           = min(var.pod_count_per_node_high_priority + var.priority_offset, 5)
   docs               = var.pod_count_per_node_high_docs
   note               = var.pod_count_per_node_high_note
 

--- a/pod-ready.tf
+++ b/pod-ready.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pod_ready" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Pod status not ready"
   query            = "min(${var.pod_ready_evaluation_period}):sum:kubernetes_state.pod.count{${local.pod_ready_filter}} by {cluster_name,namespace} - sum:kubernetes_state.pod.ready{${local.pod_ready_filter}} by {cluster_name,namespace} > 0"

--- a/pod-ready.tf
+++ b/pod-ready.tf
@@ -19,7 +19,7 @@ module "pod_ready" {
   alerting_enabled   = var.pod_ready_alerting_enabled
   critical_threshold = 0
   # No warning possible for status that is either 0 or 1
-  priority = var.pod_ready_priority
+  priority = min(var.pod_ready_priority + var.priority_offset, 5)
   docs     = var.pod_ready_docs
   note     = var.pod_ready_note
 

--- a/pod-ready.tf
+++ b/pod-ready.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "pod_ready" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Pod status not ready"
   query            = "min(${var.pod_ready_evaluation_period}):sum:kubernetes_state.pod.count{${local.pod_ready_filter}} by {cluster_name,namespace} - sum:kubernetes_state.pod.ready{${local.pod_ready_filter}} by {cluster_name,namespace} > 0"

--- a/pod-restarts.tf
+++ b/pod-restarts.tf
@@ -19,7 +19,7 @@ module "pod_restarts" {
   alerting_enabled   = var.pod_restarts_alerting_enabled
   critical_threshold = var.pod_restarts_critical
   warning_threshold  = var.pod_restarts_warning
-  priority           = var.pod_restarts_priority
+  priority           = min(var.pod_restarts_priority + var.priority_offset, 5)
   docs               = var.pod_restarts_docs
   note               = var.pod_restarts_note
 

--- a/pod-restarts.tf
+++ b/pod-restarts.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "pod_restarts" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Restarting Pods"
   query            = "change(avg(${var.pod_restarts_evaluation_period}),${var.pod_restarts_evaluation_period}):exclude_null(avg:kubernetes.containers.restarts{${local.pod_restarts_filter}} by {pod_name}) > ${var.pod_restarts_critical}"

--- a/pod-restarts.tf
+++ b/pod-restarts.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pod_restarts" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Restarting Pods"
   query            = "change(avg(${var.pod_restarts_evaluation_period}),${var.pod_restarts_evaluation_period}):exclude_null(avg:kubernetes.containers.restarts{${local.pod_restarts_filter}} by {pod_name}) > ${var.pod_restarts_critical}"

--- a/pods-failed.tf
+++ b/pods-failed.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pods_failed" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name  = "Pods Failed"
   query = "min(${var.pods_failed_evaluation_period}):default_zero(max:kubernetes_state.pod.status_phase{phase:failed${var.filter_str_concatenation}${local.pods_failed_filter}} by {namespace}) > ${var.pods_failed_critical}"

--- a/pods-failed.tf
+++ b/pods-failed.tf
@@ -22,7 +22,7 @@ module "pods_failed" {
   alerting_enabled   = var.pods_failed_alerting_enabled
   warning_threshold  = var.pods_failed_warning
   critical_threshold = var.pods_failed_critical
-  priority           = var.pods_failed_priority
+  priority           = min(var.pods_failed_priority + var.priority_offset, 5)
   docs               = var.pods_failed_docs
   note               = var.pods_failed_note
 

--- a/pods-failed.tf
+++ b/pods-failed.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "pods_failed" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name  = "Pods Failed"
   query = "min(${var.pods_failed_evaluation_period}):default_zero(max:kubernetes_state.pod.status_phase{phase:failed${var.filter_str_concatenation}${local.pods_failed_filter}} by {namespace}) > ${var.pods_failed_critical}"

--- a/pods-pending.tf
+++ b/pods-pending.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pods_pending" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name  = "Pods Pending"
   query = "min(${var.pods_pending_evaluation_period}):default_zero(max:kubernetes_state.pod.status_phase{phase:pending${var.filter_str_concatenation}${local.pods_pending_filter}} by {namespace}) > ${var.pods_pending_critical}"

--- a/pods-pending.tf
+++ b/pods-pending.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "pods_pending" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name  = "Pods Pending"
   query = "min(${var.pods_pending_evaluation_period}):default_zero(max:kubernetes_state.pod.status_phase{phase:pending${var.filter_str_concatenation}${local.pods_pending_filter}} by {namespace}) > ${var.pods_pending_critical}"

--- a/pods-pending.tf
+++ b/pods-pending.tf
@@ -22,7 +22,7 @@ module "pods_pending" {
   alerting_enabled   = var.pods_pending_alerting_enabled
   warning_threshold  = var.pods_pending_warning
   critical_threshold = var.pods_pending_critical
-  priority           = var.pods_pending_priority
+  priority           = min(var.pods_pending_priority + var.priority_offset, 5)
   docs               = var.pods_pending_docs
   note               = var.pods_pending_note
 

--- a/replicaset-incomplete.tf
+++ b/replicaset-incomplete.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "replicaset_incomplete" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name             = "Replicaset Incomplete"
   query            = "min(${var.replicaset_incomplete_evaluation_period}):max:kubernetes_state.replicaset.replicas_desired{${local.replicaset_incomplete_filter}} by {kube_replica_set,cluster_name} - min:kubernetes_state.replicaset.replicas_ready{${local.replicaset_incomplete_filter}} by {kube_replica_set,cluster_name} > ${var.replicaset_incomplete_critical}"

--- a/replicaset-incomplete.tf
+++ b/replicaset-incomplete.tf
@@ -19,7 +19,7 @@ module "replicaset_incomplete" {
   alerting_enabled   = var.replicaset_incomplete_alerting_enabled
   critical_threshold = var.replicaset_incomplete_critical
   # No warning threshold for this monitor
-  priority = var.replicaset_incomplete_priority
+  priority = min(var.replicaset_incomplete_priority + var.priority_offset, 5)
   docs     = var.replicaset_incomplete_docs
   note     = var.replicaset_incomplete_note
 

--- a/replicaset-incomplete.tf
+++ b/replicaset-incomplete.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 module "replicaset_incomplete" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name             = "Replicaset Incomplete"
   query            = "min(${var.replicaset_incomplete_evaluation_period}):max:kubernetes_state.replicaset.replicas_desired{${local.replicaset_incomplete_filter}} by {kube_replica_set,cluster_name} - min:kubernetes_state.replicaset.replicas_ready{${local.replicaset_incomplete_filter}} by {kube_replica_set,cluster_name} > ${var.replicaset_incomplete_critical}"

--- a/replicaset-unavailable.tf
+++ b/replicaset-unavailable.tf
@@ -8,7 +8,8 @@ locals {
 }
 
 module "replicaset_unavailable" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
+  source  = "kabisa/generic-monitor/datadog"
+  version = "0.7.1"
 
   name = "Replicaset Unavailable"
   # This (ab)uses a division by zero to make sure we don't get alerts when nr of desired pods < 2

--- a/replicaset-unavailable.tf
+++ b/replicaset-unavailable.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 module "replicaset_unavailable" {
-  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.0"
+  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.7.1"
 
   name = "Replicaset Unavailable"
   # This (ab)uses a division by zero to make sure we don't get alerts when nr of desired pods < 2

--- a/replicaset-unavailable.tf
+++ b/replicaset-unavailable.tf
@@ -22,7 +22,7 @@ module "replicaset_unavailable" {
   alerting_enabled   = var.replicaset_unavailable_alerting_enabled
   critical_threshold = 0
   # No warning threshold for this monitor
-  priority = var.replicaset_unavailable_priority
+  priority = min(var.replicaset_unavailable_priority + var.priority_offset, 5)
   docs     = var.replicaset_unavailable_docs
   note     = var.replicaset_unavailable_note
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,3 +56,8 @@ variable "filter_str_concatenation" {
   description = "If you use an IN expression you need to switch from , to AND"
   default     = ","
 }
+
+variable "priority_offset" {
+  description = "For non production workloads we can +1 on the priorities"
+  default     = 0
+}


### PR DESCRIPTION
Closing other PR in favour of this one: https://github.com/kabisa/terraform-datadog-kubernetes/pull/15

- Capacity metrics were based on k8s 1.18 metrics. 
- Add priority offset for nonprd configs
- Now use modules from TF registry in stead of git
- Upped patch version of generic monitor